### PR TITLE
chore(android): android max cache size is 200MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pod 'PINCache', :modular_headers => true
 
 ## Usage
 
-Currently max size on iOS is 50MB and 100MB on Android. 
+Currently max size on iOS is 50MB and 200MB on Android. 
 
 ```js
 await write('key', 'value');

--- a/android/src/main/java/com/candlefinance/cache/CacheModule.kt
+++ b/android/src/main/java/com/candlefinance/cache/CacheModule.kt
@@ -21,7 +21,7 @@
       db = AndroidDiskCache.Builder
         .folder(cacheDir)
         .appVersion(1)
-        .maxSize(1024 * 1024 * 200) // 100MB
+        .maxSize(1024 * 1024 * 200) // 200MB
         .dispatcher(Dispatchers.IO)
         .build()
     }


### PR DESCRIPTION
According to `AndroidDiskCache.maxSize` maximum storage is set to 200MB right now